### PR TITLE
Manually set date strings to end in 00:00:00.000Z to deal with DST

### DIFF
--- a/client/src/pages/WeeklyTable.js
+++ b/client/src/pages/WeeklyTable.js
@@ -71,12 +71,10 @@ const WeeklyTable = ({
 	const [currentMonday, setCurrentMonday] = useState(startOfTheWeekDate);
 
 	let week = [];
-	const year = currentMonday.getFullYear();
-	const month = currentMonday.getMonth();
-	let date = currentMonday.getDate();
-
+	let currentMoment = moment(currentMonday);
 	for (let i = 0; i < 5; i++) {
-		week.push(new Date(year, month, date + i).toISOString());
+		week.push(currentMoment.format("yyyy-MM-DD") + "T00:00:00.000Z");
+		currentMoment.add(1, "day");
 	}
 
 	const bookingsByRow = getBookingsByRow(bookings, week);

--- a/server/api.js
+++ b/server/api.js
@@ -55,7 +55,7 @@ router.get("/bookings", async (req, res) => {
 				name: row.username,
 				desk_id: row.desk_id,
 				desk: row.desk_name,
-				date: row.booking_date,
+				date: moment(row.booking_date).format("yyyy-MM-DD") + "T00:00:00.000Z",
 			};
 		});
 		res.json(bookings);


### PR DESCRIPTION
DST (daylight savings time) interacts poorly with date math (whether using moment or using javascript dates): when converted back to an iso string, 25 march + 1 week gives an iso string that is 11pm instead of midnight.

Probably we should just not have used complete isostrings to store the date, but only the date portion + moment to manipulate and display. For now, manually set them all to end in 00:00:00.000Z  - this possibly doesn't work when we go back to winter time in 6 months?